### PR TITLE
fix SIGHUP reload

### DIFF
--- a/internal/vm/loader.go
+++ b/internal/vm/loader.go
@@ -430,7 +430,7 @@ func NewLoader(lines <-chan *logline.LogLine, wg *sync.WaitGroup, programPath st
 	go func() {
 		defer l.wg.Done()
 		<-initDone
-		if l.programPath != "" {
+		if l.programPath == "" {
 			glog.Info("no program reload on SIGHUP without programPath")
 			return
 		}


### PR DESCRIPTION
obviously there is a typo in SIGHUP handler install: instead of checking for non-empty path it refuses to install handler if path is not empty